### PR TITLE
fix error "source_ips not an id of an argument or group"

### DIFF
--- a/armada/src/args.rs
+++ b/armada/src/args.rs
@@ -200,7 +200,7 @@ fn get_timeout(matches: &ArgMatches) -> Duration {
 }
 
 fn get_source_ip_addresses(matches: &ArgMatches) -> Option<Vec<IpAddr>> {
-    matches.values_of("source_ips").map(|values| {
+    matches.values_of("source_ip").map(|values| {
         values
             .map(|value| IpAddr::from_str(value).expect(&format!("Unable to parse source IP address '{}'.", value)))
             .collect()


### PR DESCRIPTION
A typo in args.rs makes armada scans panic because clap is looking for the wrong string to match to, this does not affect the current release of armada on cargo, but does affect armada when building from source